### PR TITLE
Require GAP >= 4.9

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -108,7 +108,7 @@ PackageDoc := rec(
 ),
 
 Dependencies := rec(
-  GAP := ">= 4.8",
+  GAP := ">= 4.9",
   NeededOtherPackages := [ [ "autpgrp", ">=1.5" ] ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := []

--- a/README
+++ b/README
@@ -59,7 +59,7 @@ it is also possible to keep an additional `pkg' directory in your private
 directories, see section "ref:Installing  GAP  Packages"  of  the  GAP  4
 reference manual for details on how to do this.)
 
-ANUPQ package requires at least GAP 4.8 and AutPGrp 1.5, although we
+ANUPQ package requires at least GAP 4.9 and AutPGrp 1.5, although we
 recommend using the most recent versions of each. ANUPQ optionally
 supports using GMP for large integer support.
 

--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,7 @@ AC_CHECK_HEADERS([stdlib.h string.h sys/time.h])
 dnl ##
 dnl ## Locate the GAP root dir
 dnl ##
-AC_FIND_GAP
+FIND_GAP
 
 
 dnl ##
@@ -77,12 +77,7 @@ else
 	# Try using static linked GMP in the specified location
 	if test "x$with_gmp" = "xyes" ; then
 		# Try to use GAP's GMP, if available
-		# first for GAP <= 4.8 ...
-		GMP_HOME="$GAPROOT/bin/$GAPARCH/extern/gmp"
-		# ... then for GAP >= 4.9
-		if ! test -d "$GMP_HOME" ; then
-			GMP_HOME="$GAPROOT/extern/install/gmp"
-		fi
+        GMP_HOME="$GAPROOT/extern/install/gmp"
 	else
 		GMP_HOME="$with_gmp"
 	fi;

--- a/doc/install.xml
+++ b/doc/install.xml
@@ -7,7 +7,7 @@ it is known to work on Linux and Mac OS X, and also on Windows
 equipped with cygwin.
 <P/>
 
-The current version of the &ANUPQ; package requires &GAP;&nbsp;4.8, and
+The current version of the &ANUPQ; package requires &GAP;&nbsp;4.9, and
 version 1.2 of the &AutPGrp; package. However, we recommend using
 at least &GAP;&nbsp;4.6 and &AutPGrp;&nbsp;1.5.
 <P/>

--- a/m4/find_gap.m4
+++ b/m4/find_gap.m4
@@ -3,7 +3,7 @@
 # Can be configured using --with-gaproot=...
 #######################################################################
 
-AC_DEFUN([AC_FIND_GAP],
+AC_DEFUN([FIND_GAP],
 [
   AC_LANG_PUSH([C])
 
@@ -18,10 +18,9 @@ AC_DEFUN([AC_FIND_GAP],
   AC_MSG_CHECKING([for GAP root directory])
   GAPROOT="../.."
 
-  #Allow the user to specify the location of GAP
-  #
+  # Allow the user to specify the location of GAP
   AC_ARG_WITH(gaproot,
-    [AC_HELP_STRING([--with-gaproot=<path>], [specify root of GAP installation])],
+    [AS_HELP_STRING([--with-gaproot=<path>], [specify root of GAP installation])],
     [GAPROOT="$withval"])
 
   # Convert the path to absolute
@@ -72,64 +71,16 @@ AC_DEFUN([AC_FIND_GAP],
     AC_MSG_ERROR([Unable to find plausible GAParch information.])
   fi
 
-
-  AC_MSG_CHECKING([for GAP >= 4.9])
-  # test if this GAP >= 4.9
-  if test "x$GAP_CPPFLAGS" != x; then
-    AC_MSG_RESULT([yes])
-  else
-    AC_MSG_RESULT([no])
-    #####################################
-    # Now check for the GAP header files
-
-    bad=0
-    AC_MSG_CHECKING([for GAP include files])
-    if test -r $GAPROOT/src/compiled.h; then
-      AC_MSG_RESULT([$GAPROOT/src/compiled.h])
-    else
-      AC_MSG_RESULT([Not found])
-      bad=1
-    fi
-    AC_MSG_CHECKING([for GAP config.h])
-    if test -r $GAPROOT/bin/$GAPARCH/config.h; then
-      AC_MSG_RESULT([$GAPROOT/bin/$GAPARCH/config.h])
-    else
-      AC_MSG_RESULT([Not found])
-      bad=1
-    fi
-
-    if test "x$bad" = "x1"; then
-      echo ""
-      echo "********************************************************************"
-      echo "  ERROR"
-      echo ""
-      echo "  Failed to find the GAP source header files in src/ and"
-      echo "  GAP's config.h in the architecture dependend directory"
-      echo ""
-      echo "  The kernel build process expects to find the normal GAP "
-      echo "  root directory structure as it is after building GAP itself, and"
-      echo "  in particular the files"
-      echo "      <gaproot>/sysinfo.gap"
-      echo "      <gaproot>/src/<includes>"
-      echo "  and <gaproot>/bin/<architecture>/bin/config.h."
-      echo "  Please make sure that your GAP root directory structure"
-      echo "  conforms to this layout, or give the correct GAP root using"
-      echo "  --with-gaproot=<path>"
-      echo "********************************************************************"
-      echo ""
-      AC_MSG_ERROR([Unable to find GAP include files in /src subdirectory])
-    fi
-
-    ARCHPATH=$GAPROOT/bin/$GAPARCH
-    GAP_CPPFLAGS="-I$GAPROOT -iquote $GAPROOT/src -I$ARCHPATH"
-
-    AC_MSG_CHECKING([for GAP's gmp.h location])
-    if test -r "$ARCHPATH/extern/gmp/include/gmp.h"; then
-      GAP_CPPFLAGS="$GAP_CPPFLAGS -I$ARCHPATH/extern/gmp/include"
-      AC_MSG_RESULT([$ARCHPATH/extern/gmp/include/gmp.h])
-    else
-      AC_MSG_RESULT([not found, GAP was compiled without its own GMP])
-    fi
+  # require GAP >= 4.9
+  if test "x$GAP_CPPFLAGS" = x; then
+    echo ""
+    echo "********************************************************************"
+    echo "  ERROR"
+    echo ""
+    echo "  This version of GAP is too old and not supported by this package."
+    echo "********************************************************************"
+    echo ""
+    AC_MSG_ERROR([No GAP_CPPFLAGS is given])
   fi
 
   AC_SUBST(GAPARCH)


### PR DESCRIPTION
... to simplify build system, and prepare for future changes.

GAP 4.9 is now two years old, so this shouldn't be an undue burden;
people can still use older versions of anupq if they really are stuck
with an older version of GAP.