### PR TITLE
Update GitHub Actions integration and run an existent test file

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,13 +27,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: gap-actions/setup-gap-for-packages@v1
+      - uses: gap-actions/setup-gap@v2
         with:
           GAPBRANCH: ${{ matrix.gap-branch }}
           ABI: ${{ matrix.ABI }}
-      - uses: gap-actions/run-test-for-packages@v1
+      - uses: gap-actions/build-pkg@v1
+      - uses: gap-actions/run-pkg-tests@v2
         with:
-          GAP_TESTFILE: "tst/teststandard.g"
+          GAP_TESTFILE: "tst/testinstall.g"
+      - uses: gap-actions/process-coverage@v1
 
   # The documentation job
   manual:
@@ -44,8 +46,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: gap-actions/setup-gap-for-packages@v1
-      - uses: gap-actions/compile-documentation-for-packages@v1
+      - uses: gap-actions/setup-gap@v2
+      - uses: gap-actions/build-pkg-docs@v1
         with:
           use-latex: 'true'
       - name: 'Upload documentation'


### PR DESCRIPTION
Currently, the CI isn't actually doing anything, because the file `tst/teststandard.g` does not exist in this package, see https://github.com/gap-packages/anupq/runs/2315066518?check_suite_focus=true for an example of that. There is a `tst/testall.g` and a `tst/testinstall.g`. Hopefully this takes a reasonably short amount of time.

I also took the opportunity to use the more up-to-date `gap-actions` stuff.