### PR TITLE
Suppress a test output with incorrect pluralization

### DIFF
--- a/tst/anusp.tst
+++ b/tst/anusp.tst
@@ -44,8 +44,7 @@ gap> H := Pq( G : Prime := 2, ClassBound := 1 );
 gap> hom := GroupHomomorphismByImages( H, H, [H.1, H.2], [H.2, H.1 * H.2] );
 [ f1, f2 ] -> [ f2, f1*f2 ]
 gap> SetIsBijective( hom, true );
-gap> A := GroupByGenerators( [hom] );
-<group with 1 generators>
+gap> A := GroupByGenerators( [hom] );;
 gap> Order( A );
 3
 gap> SetAutomorphismGroup( H, A );


### PR DESCRIPTION
This updates the package to make its tests run against the PR https://github.com/gap-system/gap/pull/4050, which I hope to merge into GAP in the near future. The PR will make the output become the correctly-pluralised `<group with 1 generator>`, without the `s`.

Unfortunately I seem to have overlooked this package until now, and I'm sorry to have missed the recent release.