### PR TITLE
Cygwin fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -166,9 +166,9 @@ pq_SOURCES = \
     src/main.c
 
 
-all-local: pq
+all-local: pq$(EXEEXT)
 	$(mkdir_p) $(top_srcdir)/$(BINARCHDIR)
-	cp pq $(abs_top_srcdir)/$(BINARCHDIR)
+	cp pq$(EXEEXT) $(abs_top_srcdir)/$(BINARCHDIR)
 	@echo "SUCCESS!"
 
 clean-local:

--- a/include/global.h
+++ b/include/global.h
@@ -14,10 +14,10 @@
 
 #define GAP_LIBRARY 2
 
-int Group_library;
-int Compact_Description;
-int Compact_Order;
-char *Group_library_file;
+extern int Group_library;
+extern int Compact_Description;
+extern int Compact_Order;
+extern char *Group_library_file;
 
 extern Logical GAP4iostream;
 

--- a/include/pcp_vars.h
+++ b/include/pcp_vars.h
@@ -78,6 +78,6 @@ struct pcp_vars {
 
 };
 
-int     *y_address;     /* definition of storage for presentation */
+extern int     *y_address;     /* definition of storage for presentation */
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -46,7 +46,17 @@ int work_space = PQSPACE;
 int format = PRETTY;
 int menu = DEFAULT_MENU;
 Logical StandardPresentation = FALSE;
+
+/* From pcp_vars.h */
+int *y_address = 0;
+
+/* From global.h */
+int Group_library = 0;
+int Compact_Description = 0;
+int Compact_Order = 0;
+char *Group_library_file = 0;
 Logical GAP4iostream = FALSE;
+
 
 static int process_parameters(int argc, char **argv);
 


### PR DESCRIPTION
1) Handle .exe file extension (like a similar fix in nq)

2) Remove global variables which are declared in headers (this could break code which uses part of pq as a library, but the package itself never seems to do that at least).