### PR TITLE
close the stream in `PqDescendants`

### DIFF
--- a/lib/anupga.gi
+++ b/lib/anupga.gi
@@ -352,6 +352,9 @@ InstallGlobalFunction( PQ_DESCENDANTS, function( args )
     if HasIsCapable(datarec.group) and not IsCapable(datarec.group) and 
        VALUE_PQ_OPTION("SetupFile") = fail then
         datarec.descendants := [];
+        if datarec.calltype = "non-interactive" then
+          PQ_COMPLETE_NONINTERACTIVE_FUNC_CALL(datarec);
+        fi;
         return datarec.descendants;
     fi;
 

--- a/tst/bugfix.tst
+++ b/tst/bugfix.tst
@@ -28,6 +28,12 @@ gap> PqDescendantsTreeCoclassOne( PqStart( G ) : TreeDepth := 5, CapableDescenda
 #I  Number of descendants of group #1;1 #1;1 #1;1 to class 4: 1
 #I  Number of descendants of group #1;1 #1;1 #1;1 #1;1 to class 5: 1
 
+# Check that the stream gets closed also in early exit cases.
+gap> G:= ExtraspecialGroup( 3^3, "-" );;
+gap> IsCapable( G );
+false
+gap> for i in [ 1 .. 100 ] do PqDescendants( G ); od;
+
 #
 gap> PqQuitAll();
 gap> STOP_TEST( "bugfix.tst", 1 );


### PR DESCRIPTION
otherwise the process is still running,
and calling `PqDescendants` too many times will result in a `"failed to launch child process"` error in `PQ_START`.