### PR TITLE
Resolve some GCC 16 warnings

### DIFF
--- a/src/echelon.c
+++ b/src/echelon.c
@@ -39,7 +39,7 @@ int echelon(struct pcp_vars *pcp)
    register int value;
    register int free;
 
-   register Logical trivial;
+   register Logical trivial = FALSE;
    register Logical first;
 
    register int p = pcp->p;

--- a/src/extra_relations.c
+++ b/src/extra_relations.c
@@ -420,7 +420,8 @@ void extra_relations(struct exp_vars *exp_flag, struct pcp_vars *pcp)
             gen_i = gen[i];
             for (j = i + 1; j <= length && !exit; ++j) {
                entry = y[structure + gen[j]];
-               exit = (gen_i == PART2(entry) || gen_i == PART3(entry));
+               exit = ((unsigned int)gen_i == PART2(entry) ||
+                       (unsigned int)gen_i == PART3(entry));
             }
             if (exit) {
                if (exp_flag->filter == TRUE)

--- a/src/pretty_filter.c
+++ b/src/pretty_filter.c
@@ -45,7 +45,8 @@ int pretty_filter(FILE *file, int *max_class, int *output, struct pcp_vars *pcp)
    int nrels = 0;
    int end = MAXIDENT - 1;
 
-   int count, posn;
+   int count;
+   long posn = 0;
    int ptr, relp, length;
    int i = 1;
    char c;
@@ -320,7 +321,8 @@ void pretty_read_relations(int output, int *max_class, struct pcp_vars *pcp)
    int i = 1;
    char c;
    int nrels = 0;
-   int count, posn;
+   int count;
+   long posn = 0;
    word w;
    word_link *root = word_link_create();
    word_link *wlp = 0;


### PR DESCRIPTION
Initialize values on compiler-ambiguous paths, preserve
ftell results in long integers, and compare packed generator
fields with matching signedness.

Co-authored-by: Codex <codex@openai.com>
